### PR TITLE
Disable daily scheduled market research workflows

### DIFF
--- a/.github/workflows/research-bleep-that-shit.yml
+++ b/.github/workflows/research-bleep-that-shit.yml
@@ -1,8 +1,8 @@
 name: Research bleep-that-shit
 
 on:
-  schedule:
-    - cron: '5 9 * * *'  # Daily at 9:05am UTC
+  # schedule:
+  #   - cron: '5 9 * * *'  # Daily at 9:05am UTC
   workflow_dispatch:
 
 env:

--- a/.github/workflows/research-demo-recorder.yml
+++ b/.github/workflows/research-demo-recorder.yml
@@ -1,8 +1,8 @@
 name: Research demo-recorder
 
 on:
-  schedule:
-    - cron: '15 9 * * *'  # Daily at 9:15am UTC
+  # schedule:
+  #   - cron: '15 9 * * *'  # Daily at 9:15am UTC
   workflow_dispatch:
 
 env:

--- a/.github/workflows/research-reddit-market-research.yml
+++ b/.github/workflows/research-reddit-market-research.yml
@@ -1,8 +1,8 @@
 name: Research reddit-market-research
 
 on:
-  schedule:
-    - cron: '10 9 * * *'  # Daily at 9:10am UTC
+  # schedule:
+  #   - cron: '10 9 * * *'  # Daily at 9:10am UTC
   workflow_dispatch:
 
 env:

--- a/.github/workflows/research-seating-arrangement.yml
+++ b/.github/workflows/research-seating-arrangement.yml
@@ -1,8 +1,8 @@
 name: Research seating-arrangement
 
 on:
-  schedule:
-    - cron: '0 9 * * *'  # Daily at 9am UTC
+  # schedule:
+  #   - cron: '0 9 * * *'  # Daily at 9am UTC
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
## Summary
- Disables automatic daily cron triggers for all 4 market research workflows
- Workflows can still be run manually via `workflow_dispatch`

## Test plan
- [ ] Verify workflows no longer trigger on schedule
- [ ] Confirm manual dispatch still works from GitHub Actions UI